### PR TITLE
 feat(savings): add Tagesgeld savings account endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Scalable Capital doesn't offer a public API. This project fills that gap: it's a
 | **Live quotes** | Bid, ask, and mid price per ISIN with per-timeframe performance, streamed via SSE |
 | **Transactions** | Full history with type, status, date, description, amount, ISIN, and buy/sell side; cursor-paginated |
 | **Transaction details** | Individual transaction breakdown by ID |
+| **Tagesgeld savings** | Balance, interest rate, next payout date; paginated savings transaction history |
 
 ## Examples
 
@@ -82,6 +83,8 @@ Once the server is running, interactive docs are also available at **http://127.
 | `GET`      | `/quotes/stream?isins=IE00B4L5Y983,…` | Real-time quote ticks per ISIN (SSE)  |
 | `GET`      | `/transactions`                        | Transaction history                   |
 | `GET`      | `/transactions/:id`                    | Single transaction details            |
+| `GET`      | `/savings`                             | Tagesgeld balance, interest rate, next payout date |
+| `GET`      | `/savings/transactions`                | Savings transaction history (`?limit=50`) |
 | `POST`     | `/proxy`                               | Pass-through for raw GraphQL queries  |
 
 ### Quick example

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,10 @@ components:
           type: string
         portfolioId:
           type: string
+        savingsId:
+          type: string
+          nullable: true
+          description: Savings account ID (Tagesgeld). Null if the user has no savings account.
         expiresAt:
           type: number
           description: Unix timestamp (ms) when the session expires. Derived as the minimum of 8 hours from login and the earliest Scalable Capital cookie expiry.
@@ -42,6 +46,10 @@ components:
           type: string
         portfolioId:
           type: string
+        savingsId:
+          type: string
+          nullable: true
+          description: Savings account ID (Tagesgeld). Null if the user has no savings account.
         expiresAt:
           type: number
 
@@ -275,6 +283,75 @@ components:
                 type: number
                 description: Absolute return in account currency.
                 example: 0.61
+
+    SavingsTransaction:
+      type: object
+      required: [id, type, status, description, amount, currency, lastEventDateTime, cashTransactionType]
+      properties:
+        id:
+          type: string
+          example: "THEQVT1GGEOZJVNRTSMUII"
+        type:
+          type: string
+          example: "CASH_TRANSACTION"
+        status:
+          type: string
+          example: "SETTLED"
+        description:
+          type: string
+          example: "Scalable Capital Tagesgeld Auszahlung"
+        amount:
+          type: number
+          example: 2500
+        currency:
+          type: string
+          example: "EUR"
+        lastEventDateTime:
+          type: string
+          description: ISO-8601 datetime string.
+          example: "2026-03-16T00:00:00.000Z"
+        cashTransactionType:
+          type: string
+          enum: [WITHDRAWAL, CASH_TRANSFER_IN, CASH_TRANSFER_OUT, INTEREST_PAYOUT]
+          example: "WITHDRAWAL"
+
+    SavingsOverview:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The savings account ID.
+          example: "2Yz9B847EvYmMdmJN68ywR"
+        totalAmount:
+          type: number
+          description: Current account balance in EUR.
+          example: 3400
+        depositInterestRate:
+          type: number
+          description: Nominal annual interest rate as a decimal (e.g. 0.025 = 2.5%).
+          example: 0.025
+        nextPayoutDate:
+          type: object
+          properties:
+            time:
+              type: string
+              description: ISO-8601 datetime of the next interest payout.
+              example: "2026-04-01T00:00:00.000Z"
+        interests:
+          type: object
+          properties:
+            effectiveYearlyDepositInterestRate:
+              type: number
+              description: Effective annual yield as a decimal.
+              example: 0.0252
+            estimatedNextPayoutAmount:
+              type: number
+              description: Estimated interest amount to be paid out next.
+              example: 3.9
+            currentAccruedAmount:
+              type: number
+              description: Interest accrued so far in the current period.
+              example: 1.34
 
     GraphQLRequest:
       type: object
@@ -1801,6 +1878,91 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GraphQLErrors'
+
+  /savings:
+    get:
+      summary: Savings account overview
+      operationId: getSavings
+      description: |
+        Returns the current balance, nominal and effective interest rates, next payout date,
+        and accrued interest for the Tagesgeld (overnight savings) account.
+        Returns 503 if the session has no savings account.
+      security:
+        - GatewayToken: []
+      responses:
+        '200':
+          description: Savings account overview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavingsOverview'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: Upstream GraphQL errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GraphQLErrors'
+        '503':
+          description: No savings account found in the current session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /savings/transactions:
+    get:
+      summary: Savings account transactions
+      operationId: getSavingsTransactions
+      description: |
+        Returns recent cash transactions for the Tagesgeld account (deposits, withdrawals,
+        interest payouts). Uses the `OvernightOverviewPageData` GraphQL operation.
+        Returns 503 if the session has no savings account.
+      security:
+        - GatewayToken: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Maximum number of transactions to return.
+      responses:
+        '200':
+          description: List of savings transactions
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [transactions]
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SavingsTransaction'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: Upstream GraphQL errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GraphQLErrors'
+        '503':
+          description: No savings account found in the current session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /portfolio/timeseries:
     get:

--- a/src/auth/identity.ts
+++ b/src/auth/identity.ts
@@ -1,95 +1,39 @@
 import type { Page } from 'puppeteer';
 import type { Cookie } from '../types.ts';
 
-const FIBER_WALK_SCRIPT = `(function () {
-  function visit(node) {
-    if (!node) return null;
-    if (Array.isArray(node)) {
-      for (const sub of node) { const r = visit(sub); if (r) return r; }
-      return null;
-    }
-    if (typeof node === 'object') {
-      if (node.personId) return node.personId;
-      for (const key in node) {
-        if (['children','props','security','items'].includes(key) ||
-            key.startsWith('__reactProps')) {
-          const r = visit(node[key]); if (r) return r;
-        }
-      }
-    }
-    if (node.childNodes?.forEach) {
-      for (const child of node.childNodes) { const r = visit(child); if (r) return r; }
-    }
-    return null;
-  }
-  return visit(document.body);
-})()`;
+export async function extractPersonIdFromCookies(page: Page): Promise<string> {
+  const cookies = await page.cookies();
+  const sessionCookie = cookies.find((c) => c.name === 'session');
+  if (!sessionCookie) throw new Error('[identity] No "session" cookie found.');
 
-export async function extractPersonId(page: Page): Promise<string> {
-  const result = await page.evaluate(FIBER_WALK_SCRIPT);
-  if (typeof result !== 'string' || !result) {
-    throw new Error('Could not extract personId via React fiber walk.');
-  }
-  return result;
+  const parsed = JSON.parse(decodeURIComponent(sessionCookie.value)) as unknown;
+  const userId = (parsed as { user?: { userId?: string } })?.user?.userId;
+  if (!userId) throw new Error('[identity] Could not extract userId from session cookie.');
+  return userId;
 }
 
-export async function extractPortfolioId(page: Page): Promise<string> {
-  // 1. Try URL query param (most reliable when client router has run)
-  const url = page.url();
-  const urlMatch = url.match(/portfolioId=([^&]+)/);
-  if (urlMatch?.[1]) return urlMatch[1];
+export async function extractAccountIds(page: Page): Promise<{ portfolioId: string; savingsId: string | null }> {
+  let portfolioId: string | null = null;
+  let savingsId: string | null = null;
 
-  // 2. Fallback: scan __NEXT_DATA__ for a BrokerValuation:xxx key — xxx is the portfolioId
-  const fromNextData = await page.evaluate((): string | null => {
-    try {
-      const el = document.getElementById('__NEXT_DATA__');
-      if (!el?.textContent) return null;
-      const data = JSON.parse(el.textContent) as Record<string, unknown>;
-      const result = (data?.props as Record<string, unknown>)?.initialQueryResult as Record<string, unknown> | undefined;
-      if (!result) return null;
-      for (const key of Object.keys(result)) {
-        const m = key.match(/^BrokerValuation:(.+)$/);
-        if (m?.[1]) return m[1];
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  });
-  if (fromNextData) {
-    console.log('[identity] portfolioId extracted from __NEXT_DATA__:', fromNextData);
-    return fromNextData;
-  }
-
-  // 3. Fallback: React fiber walk looking for portfolioId property
-  const fromFiber = await page.evaluate(`(function () {
-    function visit(node) {
-      if (!node) return null;
-      if (Array.isArray(node)) {
-        for (const sub of node) { const r = visit(sub); if (r) return r; }
-        return null;
-      }
-      if (typeof node === 'object') {
-        if (node.portfolioId && typeof node.portfolioId === 'string') return node.portfolioId;
-        for (const key in node) {
-          if (['children','props','security','items','portfolio','broker'].includes(key) ||
-              key.startsWith('__reactProps')) {
-            const r = visit(node[key]); if (r) return r;
-          }
-        }
-      }
-      return null;
-    }
-    return visit(document.body);
-  })()`);
-  if (typeof fromFiber === 'string' && fromFiber) {
-    console.log('[identity] portfolioId extracted via fiber walk:', fromFiber);
-    return fromFiber;
-  }
-
-  throw new Error(
-    `Could not extract portfolioId from URL (${url}), __NEXT_DATA__, or fiber walk.`,
+  const hrefs = await page.evaluate((): string[] =>
+    Array.from(document.querySelectorAll('a[href]')).map((a) => a.getAttribute('href') ?? ''),
   );
+
+  for (const href of hrefs) {
+    if (!portfolioId) {
+      const m = href.match(/portfolioId=([^&]+)/);
+      if (m?.[1]) portfolioId = m[1];
+    }
+    if (!savingsId) {
+      const m = href.match(/\/interest\/([^/?]+)/);
+      if (m?.[1]) savingsId = m[1];
+    }
+    if (portfolioId && savingsId) break;
+  }
+
+  if (!portfolioId) throw new Error('[identity] Could not extract portfolioId from cockpit page.');
+  return { portfolioId, savingsId };
 }
 
 export async function extractCookies(page: Page): Promise<Cookie[]> {

--- a/src/auth/puppeteer-login.ts
+++ b/src/auth/puppeteer-login.ts
@@ -1,7 +1,7 @@
 import puppeteer from 'puppeteer';
 import {
-  extractPortfolioId,
-  extractPersonId,
+  extractPersonIdFromCookies,
+  extractAccountIds,
   extractCookies,
 } from './identity.ts';
 import { createSession, persistSession, setSession } from './session.ts';
@@ -30,34 +30,40 @@ export async function runPuppeteerLogin(): Promise<Session> {
       { timeout: 120_000, polling: 500 },
     );
 
-    console.log('[login] Login detected. Navigating to transactions page...');
+    console.log(`[login] Login detected. Current URL: ${page.url()}`);
 
-    // Step 3: Navigate to transactions to get portfolioId from URL
-    await page.goto('https://de.scalable.capital/broker/transactions', {
-      waitUntil: 'networkidle2',
-      timeout: 30_000,
+    // Step 3: Navigate to cockpit if not already there, then wait for account cards to render.
+    if (!page.url().includes('/cockpit')) {
+      await page.goto('https://de.scalable.capital/cockpit/', {
+        waitUntil: 'networkidle2',
+        timeout: 30_000,
+      });
+      console.log(`[login] Navigated to cockpit. URL: ${page.url()}`);
+    }
+
+    await page.waitForFunction(
+      () => document.querySelector('a[href*="portfolioId="]') !== null,
+      { timeout: 30_000, polling: 500 },
+    ).catch(async () => {
+      const url = await page.evaluate(() => window.location.href);
+      const links = await page.evaluate(() =>
+        Array.from(document.querySelectorAll('a[href]')).map((a) => a.getAttribute('href')).join('\n'),
+      );
+      throw new Error(`[login] Account cards not found after 30s.\nURL: ${url}\nLinks on page:\n${links}`);
     });
 
-    // The Next.js client router adds portfolioId to the URL asynchronously — wait for it
-    await page
-      .waitForFunction(() => window.location.href.includes('portfolioId='), {
-        timeout: 120_000,
-        polling: 500,
-      })
-      .catch(() => {
-        console.log('[login] portfolioId not in URL after 10s — will try alternative extraction...');
-      });
-
-    const portfolioId = await extractPortfolioId(page);
+    // Step 4: Extract all identifiers
+    const { portfolioId, savingsId } = await extractAccountIds(page);
     console.log(`[login] Extracted portfolioId: ${portfolioId}`);
+    if (savingsId) console.log(`[login] Extracted savingsId: ${savingsId}`);
 
-    const personId = await extractPersonId(page);
+    const personId = await extractPersonIdFromCookies(page);
     console.log(`[login] Extracted personId: ${personId}`);
 
     const cookies = await extractCookies(page);
     console.log(`[login] Extracted ${cookies.length} cookies.`);
 
-    const session = createSession(cookies, personId, portfolioId);
+    const session = createSession(cookies, personId, portfolioId, savingsId);
     setSession(session);
     await persistSession(session);
 

--- a/src/auth/session.test.ts
+++ b/src/auth/session.test.ts
@@ -14,19 +14,19 @@ const mockCookies: Cookie[] = [{
 
 describe('isSessionValid', () => {
   it('returns true when expiresAt is in the future', () => {
-    const session = createSession(mockCookies, 'pid', 'portId');
+    const session = createSession(mockCookies, 'pid', 'portId', null);
     expect(isSessionValid(session)).toBe(true);
   });
 
   it('returns false when expiresAt is in the past', () => {
-    const session = createSession(mockCookies, 'pid', 'portId');
+    const session = createSession(mockCookies, 'pid', 'portId', null);
     const expired = { ...session, expiresAt: Date.now() - 1 };
     expect(isSessionValid(expired)).toBe(false);
   });
 
   it('returns false when expiresAt equals Date.now() (not strictly less-than)', () => {
     const now = Date.now();
-    const session = createSession(mockCookies, 'pid', 'portId');
+    const session = createSession(mockCookies, 'pid', 'portId', null);
     const atEdge = { ...session, expiresAt: now };
     // Date.now() will have advanced by tiny amount, so expiresAt <= Date.now()
     expect(isSessionValid(atEdge)).toBe(false);
@@ -35,7 +35,7 @@ describe('isSessionValid', () => {
 
 describe('createSession', () => {
   it('returns an object with all required fields', () => {
-    const session = createSession(mockCookies, 'person1', 'port1');
+    const session = createSession(mockCookies, 'person1', 'port1', null);
     expect(session).toMatchObject({
       cookies: mockCookies,
       personId: 'person1',
@@ -47,7 +47,7 @@ describe('createSession', () => {
 
   it('sets expiresAt to 8 hours when all cookies are session cookies (expires: -1)', () => {
     const before = Date.now();
-    const session = createSession(mockCookies, 'p', 'q');
+    const session = createSession(mockCookies, 'p', 'q', null);
     const after = Date.now();
     const eightHoursMs = 8 * 60 * 60 * 1000;
     expect(session.expiresAt).toBeGreaterThanOrEqual(before + eightHoursMs - 100);
@@ -57,7 +57,7 @@ describe('createSession', () => {
   it('uses the earliest cookie expiry when it is sooner than 8 hours', () => {
     const soon = Math.floor((Date.now() + 30 * 60 * 1000) / 1000); // 30 min from now in Unix s
     const cookiesWithExpiry: Cookie[] = [{ ...mockCookies[0], expires: soon }];
-    const session = createSession(cookiesWithExpiry, 'p', 'q');
+    const session = createSession(cookiesWithExpiry, 'p', 'q', null);
     expect(session.expiresAt).toBe(soon * 1000);
   });
 
@@ -65,7 +65,7 @@ describe('createSession', () => {
     const far = Math.floor((Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000); // 30 days
     const cookiesWithExpiry: Cookie[] = [{ ...mockCookies[0], expires: far }];
     const before = Date.now();
-    const session = createSession(cookiesWithExpiry, 'p', 'q');
+    const session = createSession(cookiesWithExpiry, 'p', 'q', null);
     const after = Date.now();
     const eightHoursMs = 8 * 60 * 60 * 1000;
     expect(session.expiresAt).toBeGreaterThanOrEqual(before + eightHoursMs - 100);

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -63,6 +63,7 @@ export function createSession(
   cookies: Cookie[],
   personId: string,
   portfolioId: string,
+  savingsId: string | null,
 ): Session {
   const now = Date.now();
   const validCookieExpiries = cookies
@@ -76,6 +77,7 @@ export function createSession(
     cookies,
     personId,
     portfolioId,
+    savingsId,
     authenticatedAt: now,
     expiresAt,
   };

--- a/src/scalable/operations/savings.ts
+++ b/src/scalable/operations/savings.ts
@@ -1,0 +1,75 @@
+export const OVERNIGHT_OVERVIEW = `
+  query OvernightOverview($savingsAccountId: ID!, $accountId: ID!) {
+    account(id: $accountId) {
+      savingsAccount(id: $savingsAccountId) {
+        id
+        ... on OvernightSavingsAccount {
+          totalAmount
+          nextPayoutDate {
+            time
+          }
+          depositInterestRate: interestRate
+          interests {
+            effectiveYearlyDepositInterestRate
+            estimatedNextPayoutAmount
+            currentAccruedAmount
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const OVERNIGHT_TRANSACTIONS = `
+  query OvernightOverviewPageData(
+    $savingsAccountId: ID!,
+    $accountId: ID!,
+    $recentTransactionsInput: SavingsAccountCashTransactionInput!
+  ) {
+    account(id: $accountId) {
+      savingsAccount(id: $savingsAccountId) {
+        id
+        ... on OvernightSavingsAccount {
+          moreTransactions(input: $recentTransactionsInput) {
+            transactions {
+              id
+              type
+              status
+              description
+              amount
+              currency
+              lastEventDateTime
+              cashTransactionType
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export interface SavingsTransaction {
+  id: string;
+  type: string;
+  status: string;
+  description: string;
+  amount: number;
+  currency: string;
+  lastEventDateTime: string;
+  cashTransactionType: string;
+}
+
+export interface OvernightSavingsAccount {
+  id: string;
+  totalAmount?: number;
+  nextPayoutDate?: { time: string };
+  depositInterestRate?: number;
+  interests?: {
+    effectiveYearlyDepositInterestRate: number;
+    estimatedNextPayoutAmount: number;
+    currentAccruedAmount: number;
+  };
+  moreTransactions?: {
+    transactions: SavingsTransaction[];
+  };
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -8,6 +8,7 @@ import portfolioRouter from './routes/portfolio.ts';
 import quotesRouter from './routes/quotes.ts';
 import securitiesRouter from './routes/securities.ts';
 import transactionsRouter from './routes/transactions.ts';
+import savingsRouter from './routes/savings.ts';
 import { spec, scalarMiddleware } from './openapi.ts';
 import type { GatewayConfig } from '../types.ts';
 
@@ -51,6 +52,7 @@ export function createApp(config: GatewayConfig): express.Application {
   app.use('/quotes', quotesRouter);
   app.use('/securities', securitiesRouter);
   app.use('/transactions', transactionsRouter);
+  app.use('/savings', savingsRouter);
 
   // Error handler — must be last
   app.use(errorHandler);

--- a/src/server/middleware/requireSession.test.ts
+++ b/src/server/middleware/requireSession.test.ts
@@ -38,7 +38,7 @@ describe('requireSession', () => {
   });
 
   it('responds 401 when session exists but isSessionValid returns false', () => {
-    mockGetSession.mockReturnValue({ cookies: [], personId: '', portfolioId: '', authenticatedAt: 0, expiresAt: 0 });
+    mockGetSession.mockReturnValue({ cookies: [], personId: '', portfolioId: '', savingsId: null, authenticatedAt: 0, expiresAt: 0 });
     mockIsSessionValid.mockReturnValue(false);
     const res = makeMockRes();
     const next = vi.fn();
@@ -48,7 +48,7 @@ describe('requireSession', () => {
   });
 
   it('calls next() when session is valid', () => {
-    mockGetSession.mockReturnValue({ cookies: [], personId: '', portfolioId: '', authenticatedAt: 0, expiresAt: Date.now() + 9999 });
+    mockGetSession.mockReturnValue({ cookies: [], personId: '', portfolioId: '', savingsId: null, authenticatedAt: 0, expiresAt: Date.now() + 9999 });
     mockIsSessionValid.mockReturnValue(true);
     const res = makeMockRes();
     const next = vi.fn();

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -12,6 +12,7 @@ router.post('/login', async (_req, res) => {
       message: 'Already authenticated.',
       personId: existing.personId,
       portfolioId: existing.portfolioId,
+      savingsId: existing.savingsId,
       expiresAt: existing.expiresAt,
     });
     return;
@@ -23,6 +24,7 @@ router.post('/login', async (_req, res) => {
     message: 'Login successful.',
     personId: session.personId,
     portfolioId: session.portfolioId,
+    savingsId: session.savingsId,
     expiresAt: session.expiresAt,
   });
 });
@@ -38,6 +40,7 @@ router.get('/status', (_req, res) => {
     authenticated: true,
     personId: session.personId,
     portfolioId: session.portfolioId,
+    savingsId: session.savingsId,
     expiresAt: session.expiresAt,
   });
 });

--- a/src/server/routes/savings.ts
+++ b/src/server/routes/savings.ts
@@ -1,0 +1,75 @@
+import { Router } from 'express';
+import { requireSession } from '../middleware/requireSession.ts';
+import { getSession } from '../../auth/session.ts';
+import { graphqlRequest } from '../../scalable/client.ts';
+import {
+  OVERNIGHT_OVERVIEW,
+  OVERNIGHT_TRANSACTIONS,
+  type OvernightSavingsAccount,
+} from '../../scalable/operations/savings.ts';
+
+const router = Router();
+
+// GET /savings — balance and interest overview
+router.get('/', requireSession, async (_req, res) => {
+  const session = getSession()!;
+  if (!session.savingsId) {
+    res.status(503).json({ error: 'No savings account found' });
+    return;
+  }
+
+  const result = await graphqlRequest<{ account: { savingsAccount: OvernightSavingsAccount } }>({
+    operationName: 'OvernightOverview',
+    query: OVERNIGHT_OVERVIEW,
+    variables: {
+      accountId: session.personId,
+      savingsAccountId: session.savingsId,
+    },
+  });
+
+  if (result.errors?.length) {
+    res.status(502).json({ errors: result.errors });
+    return;
+  }
+
+  const account = result.data?.account?.savingsAccount;
+  res.json({
+    id: account?.id,
+    totalAmount: account?.totalAmount,
+    depositInterestRate: account?.depositInterestRate,
+    nextPayoutDate: account?.nextPayoutDate,
+    interests: account?.interests,
+  });
+});
+
+// GET /savings/transactions — recent transactions
+// Query param: ?limit=50 (default 50)
+router.get('/transactions', requireSession, async (req, res) => {
+  const session = getSession()!;
+  if (!session.savingsId) {
+    res.status(503).json({ error: 'No savings account found' });
+    return;
+  }
+
+  const pageSize = req.query['limit'] ? Number(req.query['limit']) : 50;
+
+  const result = await graphqlRequest<{ account: { savingsAccount: OvernightSavingsAccount } }>({
+    operationName: 'OvernightOverviewPageData',
+    query: OVERNIGHT_TRANSACTIONS,
+    variables: {
+      accountId: session.personId,
+      savingsAccountId: session.savingsId,
+      recentTransactionsInput: { pageSize },
+    },
+  });
+
+  if (result.errors?.length) {
+    res.status(502).json({ errors: result.errors });
+    return;
+  }
+
+  const transactions = result.data?.account?.savingsAccount?.moreTransactions?.transactions ?? [];
+  res.json({ transactions });
+});
+
+export default router;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Session {
   cookies: Cookie[];
   personId: string;
   portfolioId: string;
+  savingsId: string | null;
   authenticatedAt: number;
   expiresAt: number;
 }


### PR DESCRIPTION
 ## Summary:
- Adds two new endpoints for the Tagesgeld (overnight/call money) savings account:
  - `GET /savings/overview` — balance, interest rate, next payout date, and associated IBAN
  - `GET /savings/transactions` — paginated transaction history
- Extracts `savingsId` during login (from the cockpit page) and persists it in the session                                                                    
- Refactors `identity.ts`: replaces the brittle React fiber walk with a simpler URL/DOM extraction from the cockpit page, removing ~60 lines