### PR TITLE
fix(ci): add --legacy-peer-deps to resolve missing @emnapi peer deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci --omit=optional --ignore-scripts
+      - run: npm ci --omit=optional --ignore-scripts --legacy-peer-deps
 
       - run: npm run docs
 


### PR DESCRIPTION
fix(ci): add --legacy-peer-deps to resolve missing @emnapi peer deps on Linux

The lock file is generated on macOS and lacks resolved entries for @emnapi/core, @emnapi/runtime, and @emnapi/wasi-threads. On Linux, npm 7+ auto-installs peer deps of @napi-rs/wasm-runtime and fails when those versions are not pinned in the lock file.