### PR TITLE
feat(server): add JSON 404 handler for unmatched routes

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -58,6 +58,11 @@ export function createApp(config: GatewayConfig): express.Application {
   app.use('/transactions', transactionsRouter);
   app.use('/savings', savingsRouter);
 
+  // 404 catch-all — must be before error handler
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not found.' });
+  });
+
   // Error handler — must be last
   app.use(errorHandler);
 


### PR DESCRIPTION
Unmatched routes previously returned Express's default plaintext HTML error page. A catch-all middleware now returns a consistent JSON response instead.