### PR TITLE
feat(transactions): add GET /transactions/documents/:id download endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1168,6 +1168,8 @@ paths:
           required: false
           schema:
             type: string
+            maxLength: 100
+            pattern: '^[A-Za-z0-9_-]+$'
           description: Document label from the transaction details `documents[].label` field.
           example: Kosteninformation
         - name: isin

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1129,6 +1129,81 @@ paths:
               schema:
                 $ref: '#/components/schemas/GraphQLErrors'
 
+  /transactions/documents/{id}:
+    get:
+      summary: Download transaction document
+      operationId: downloadTransactionDocument
+      description: |
+        Proxy-downloads a transaction document PDF from Scalable Capital's download API.
+        The `id` is the document ID from the `documents` array in the transaction details response.
+
+        To get the correct file, also pass the three optional query parameters that the server uses
+        to build Scalable's internal download path:
+        - `date` — date portion of `lastEventDateTime` (e.g. `2026-03-26`)
+        - `label` — document label from the `documents` array (e.g. `Kosteninformation`)
+        - `isin` — ISIN from `security.isin` (e.g. `IE00B3RBWM25`)
+
+        All three must be supplied together or omitted together. If omitted, the document ID is
+        used as the path segment (may work for some documents).
+      security:
+        - GatewayToken: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Document ID from the transaction details `documents[].id` field.
+          example: iRRfCi1iMGpLu2aZQKnKfY
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: Date portion of `lastEventDateTime` from the transaction details.
+          example: '2026-03-26'
+        - name: label
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Document label from the transaction details `documents[].label` field.
+          example: Kosteninformation
+        - name: isin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: ISIN from the transaction details `security.isin` field.
+          example: IE00B3RBWM25
+      responses:
+        '200':
+          description: PDF document binary
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid id, or invalid/incomplete date+label+isin combination
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: Upstream returned a non-2xx status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /securities/{isin}:
     get:
       summary: Full security details

--- a/src/scalable/client.ts
+++ b/src/scalable/client.ts
@@ -46,7 +46,7 @@ export function buildHeaders(portfolioId: string, cookieHeader: string): Record<
   };
 }
 
-const FETCH_TIMEOUT_MS = 30_000;
+export const FETCH_TIMEOUT_MS = 30_000;
 
 async function executeRequest<T>(
   body: GraphQLRequest,

--- a/src/scalable/client.ts
+++ b/src/scalable/client.ts
@@ -21,7 +21,7 @@ export async function ensureLogin(): Promise<void> {
   await loginInProgress;
 }
 
-const USER_AGENT =
+export const USER_AGENT =
   'unofficial-sc-api/0.1.0 (https://github.com/ffischbach/unofficial-scalable-capital-api)';
 
 export class AuthenticationError extends Error {

--- a/src/server/routes/transactions.test.ts
+++ b/src/server/routes/transactions.test.ts
@@ -244,13 +244,25 @@ describe('GET /documents/:id — document download', () => {
     expect(body).toHaveProperty('error');
   });
 
-  it('returns the upstream status when it is not ok', async () => {
+  it('returns 502 when upstream is not ok', async () => {
     upstreamFetch.mockResolvedValue(new Response(null, { status: 404 }));
 
-    const res = await fetch(`${ctx.baseUrl}/documents/missing-doc-id`);
+    const res = await fetch(`${ctx.baseUrl}/documents/nonexistent-doc`);
     const body = await res.json();
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(502);
+    expect(body).toHaveProperty('error');
+  });
+
+  it.each([
+    ['date=2026-03-26', 'only date'],
+    ['date=2026-03-26&label=Kosteninformation', 'date and label'],
+    ['label=Kosteninformation&isin=IE00B3RBWM25', 'label and isin'],
+  ])('returns 400 when partial params are provided (%s)', async (qs) => {
+    const res = await fetch(`${ctx.baseUrl}/documents/iRRfCi1iMGpLu2aZQKnKfY?${qs}`);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
     expect(body).toHaveProperty('error');
   });
 });

--- a/src/server/routes/transactions.test.ts
+++ b/src/server/routes/transactions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeMockSession, setupRouteTest } from './test-helpers.ts';
 
 vi.mock('../middleware/requireSession.ts', () => ({
@@ -9,9 +9,14 @@ vi.mock('../../auth/session.ts', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('../../scalable/client.ts', () => ({
-  graphqlRequest: vi.fn(),
-}));
+vi.mock('../../scalable/client.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../../scalable/client.ts')>();
+  return {
+    ...actual,
+    graphqlRequest: vi.fn(),
+    buildCookieHeader: vi.fn(() => 'cookie=value'),
+  };
+});
 
 import { getSession } from '../../auth/session.ts';
 import { graphqlRequest } from '../../scalable/client.ts';
@@ -166,5 +171,86 @@ describe('GET / — success', () => {
     const res = await fetch(`${ctx.baseUrl}/`);
 
     expect(res.status).toBe(502);
+  });
+});
+
+describe('GET /documents/:id — document download', () => {
+  const upstreamFetch = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    // Pass through localhost calls (test → route server); intercept Scalable calls.
+    vi.stubGlobal('fetch', (url: string | URL | Request, init?: RequestInit) => {
+      const href = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+      if (href.startsWith('https://de.scalable.capital')) {
+        return upstreamFetch(href, init);
+      }
+      return originalFetch(url, init);
+    });
+    upstreamFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('proxies a PDF response with correct headers', async () => {
+    const pdfBytes = Buffer.from('%PDF-test');
+    upstreamFetch.mockResolvedValue(
+      new Response(pdfBytes, {
+        status: 200,
+        headers: {
+          'content-type': 'application/pdf',
+          'content-disposition': 'attachment; filename="Kosteninformation.pdf"',
+        },
+      }),
+    );
+
+    const res = await fetch(`${ctx.baseUrl}/documents/iRRfCi1iMGpLu2aZQKnKfY`);
+    const body = await res.arrayBuffer();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/pdf');
+    expect(Buffer.from(body)).toEqual(pdfBytes);
+    expect(upstreamFetch).toHaveBeenCalledWith(
+      'https://de.scalable.capital/broker/api/download/iRRfCi1iMGpLu2aZQKnKfY?id=iRRfCi1iMGpLu2aZQKnKfY',
+      expect.objectContaining({ headers: expect.objectContaining({ Cookie: 'cookie=value' }) }),
+    );
+  });
+
+  it('constructs the download path from date, label, and isin', async () => {
+    upstreamFetch.mockResolvedValue(
+      new Response(Buffer.from('%PDF-test'), {
+        status: 200,
+        headers: { 'content-type': 'application/pdf' },
+      }),
+    );
+
+    await fetch(
+      `${ctx.baseUrl}/documents/iRRfCi1iMGpLu2aZQKnKfY?date=2026-03-26&label=Kosteninformation&isin=IE00B3RBWM25`,
+    );
+
+    expect(upstreamFetch).toHaveBeenCalledWith(
+      'https://de.scalable.capital/broker/api/download/2026-03-26-Kosteninformation-IE00B3RBWM25?id=iRRfCi1iMGpLu2aZQKnKfY',
+      expect.anything(),
+    );
+  });
+
+  it('returns 400 for an invalid document id', async () => {
+    const res = await fetch(`${ctx.baseUrl}/documents/inv@lid!`);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns the upstream status when it is not ok', async () => {
+    upstreamFetch.mockResolvedValue(new Response(null, { status: 404 }));
+
+    const res = await fetch(`${ctx.baseUrl}/documents/missing-doc-id`);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body).toHaveProperty('error');
   });
 });

--- a/src/server/routes/transactions.ts
+++ b/src/server/routes/transactions.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { requireSession } from '../middleware/requireSession.ts';
 import { getSession } from '../../auth/session.ts';
-import { graphqlRequest, buildCookieHeader, FETCH_TIMEOUT_MS } from '../../scalable/client.ts';
+import { graphqlRequest, buildCookieHeader, FETCH_TIMEOUT_MS, USER_AGENT } from '../../scalable/client.ts';
 import { MORE_TRANSACTIONS, TRANSACTION_DETAILS } from '../../scalable/operations/transactions.ts';
 import { ISIN_RE } from './validate.ts';
 
@@ -83,7 +83,7 @@ router.get('/:id', requireSession, async (req, res) => {
 });
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const LABEL_RE = /^[A-Za-z0-9 _-]{1,100}$/;
+const LABEL_RE = /^[A-Za-z0-9_-]{1,100}$/;
 
 // GET /transactions/documents/:id — proxy-download a transaction document PDF
 // Optional query params to construct the download path: date, label, isin
@@ -137,6 +137,7 @@ router.get('/documents/:id', requireSession, async (req, res) => {
         Cookie: cookieHeader,
         Referer: `https://de.scalable.capital/broker/transactions?portfolioId=${session.portfolioId}`,
         Origin: 'https://de.scalable.capital',
+        'User-Agent': USER_AGENT,
       },
       signal: controller.signal,
     });
@@ -145,7 +146,7 @@ router.get('/documents/:id', requireSession, async (req, res) => {
   }
 
   if (!upstream.ok) {
-    res.status(upstream.status).json({ error: `Upstream returned ${upstream.status}` });
+    res.status(502).json({ error: `Upstream returned ${upstream.status}` });
     return;
   }
 

--- a/src/server/routes/transactions.ts
+++ b/src/server/routes/transactions.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { requireSession } from '../middleware/requireSession.ts';
 import { getSession } from '../../auth/session.ts';
-import { graphqlRequest } from '../../scalable/client.ts';
+import { graphqlRequest, buildCookieHeader, FETCH_TIMEOUT_MS } from '../../scalable/client.ts';
 import { MORE_TRANSACTIONS, TRANSACTION_DETAILS } from '../../scalable/operations/transactions.ts';
 import { ISIN_RE } from './validate.ts';
+
+const DOWNLOAD_BASE_URL = 'https://de.scalable.capital/broker/api/download';
 
 const router = Router();
 
@@ -78,6 +80,82 @@ router.get('/:id', requireSession, async (req, res) => {
     return;
   }
   res.json(result.data);
+});
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const LABEL_RE = /^[A-Za-z0-9 _-]{1,100}$/;
+
+// GET /transactions/documents/:id — proxy-download a transaction document PDF
+// Optional query params to construct the download path: date, label, isin
+//   date:  lastEventDateTime date portion (e.g. "2026-03-26")
+//   label: document label (e.g. "Kosteninformation")
+//   isin:  security ISIN (e.g. "IE00B3RBWM25")
+// All three must be supplied together; if omitted the document id is used as the path segment.
+router.get('/documents/:id', requireSession, async (req, res) => {
+  const documentId = String(req.params['id']);
+
+  if (!TRANSACTION_ID_RE.test(documentId)) {
+    res.status(400).json({ error: 'Invalid document id.' });
+    return;
+  }
+
+  const date = req.query['date'] ? String(req.query['date']) : undefined;
+  const label = req.query['label'] ? String(req.query['label']) : undefined;
+  const isin = req.query['isin'] ? String(req.query['isin']) : undefined;
+
+  const hasAll = date !== undefined && label !== undefined && isin !== undefined;
+  const hasAny = date !== undefined || label !== undefined || isin !== undefined;
+  if (hasAny && !hasAll) {
+    res.status(400).json({ error: 'Provide all three of date, label, and isin, or none of them.' });
+    return;
+  }
+  if (date !== undefined && !DATE_RE.test(date)) {
+    res.status(400).json({ error: 'date must be in YYYY-MM-DD format.' });
+    return;
+  }
+  if (label !== undefined && !LABEL_RE.test(label)) {
+    res.status(400).json({ error: 'label contains invalid characters.' });
+    return;
+  }
+  if (isin !== undefined && !ISIN_RE.test(isin)) {
+    res.status(400).json({ error: 'isin must be a 12-character alphanumeric string.' });
+    return;
+  }
+
+  const slug = hasAll ? `${date}-${label}-${isin}` : documentId;
+  const session = getSession()!;
+  const cookieHeader = buildCookieHeader(session.cookies);
+  const url = `${DOWNLOAD_BASE_URL}/${encodeURIComponent(slug)}?id=${encodeURIComponent(documentId)}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      headers: {
+        Cookie: cookieHeader,
+        Referer: `https://de.scalable.capital/broker/transactions?portfolioId=${session.portfolioId}`,
+        Origin: 'https://de.scalable.capital',
+      },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!upstream.ok) {
+    res.status(upstream.status).json({ error: `Upstream returned ${upstream.status}` });
+    return;
+  }
+
+  const contentType = upstream.headers.get('content-type') ?? 'application/octet-stream';
+  const contentDisposition = upstream.headers.get('content-disposition');
+  res.setHeader('Content-Type', contentType);
+  if (contentDisposition) res.setHeader('Content-Disposition', contentDisposition);
+
+  const buffer = await upstream.arrayBuffer();
+  res.send(Buffer.from(buffer));
 });
 
 export default router;


### PR DESCRIPTION
Proxy-downloads transaction document PDFs from Scalable Capital. Accepts date, label, and isin as explicit params instead of an opaque slug so callers can pass values directly from the transaction details response. Updates openapi.yaml docs accordingly.